### PR TITLE
Fixed FTP notifications

### DIFF
--- a/internal/cmd/server/ftp.go
+++ b/internal/cmd/server/ftp.go
@@ -36,7 +36,9 @@ func FTPEvent(e *ftpx.Event) *models.Event {
 
 	return &models.Event{
 		Protocol:   models.ProtoFTP,
-		RW:         e.Log,
+		R:          e.R,
+		W:          e.W,
+		RW:         e.RW,
 		Meta:       structs.Map(meta),
 		RemoteAddr: e.RemoteAddr.String(),
 		ReceivedAt: e.ReceivedAt,

--- a/pkg/ftpx/ftpx_test.go
+++ b/pkg/ftpx/ftpx_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 			}
 		}),
 		ftpx.OnClose(func(e *ftpx.Event) {
-			notifier.Notify(e.RemoteAddr, e.Log, map[string]interface{}{})
+			notifier.Notify(e.RemoteAddr, e.RW, map[string]interface{}{})
 		}),
 	}
 

--- a/pkg/netx/logging.go
+++ b/pkg/netx/logging.go
@@ -18,7 +18,7 @@ func (l *LoggingListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
-	return NewLoggingCon(conn), nil
+	return NewLoggingConn(conn), nil
 }
 
 // LoggingConn wraps net.Conn to save conversation log.
@@ -42,8 +42,8 @@ type LoggingConn struct {
 	OnClose func()
 }
 
-// NewLoggingCon wraps net.Conn and adds logging.
-func NewLoggingCon(conn net.Conn) *LoggingConn {
+// NewLoggingConn wraps net.Conn and adds logging.
+func NewLoggingConn(conn net.Conn) *LoggingConn {
 	c := &LoggingConn{
 		Conn: conn,
 	}

--- a/pkg/smtpx/session.go
+++ b/pkg/smtpx/session.go
@@ -105,7 +105,7 @@ type session struct {
 // handleConn creates new SMTP session and handles connection with it.
 func handleConn(ctx context.Context, conn net.Conn, opts options) error {
 
-	newConn := netx.NewLoggingCon(conn)
+	newConn := netx.NewLoggingConn(conn)
 
 	sess := &session{
 		messages:  opts.messages,
@@ -148,7 +148,7 @@ func (s *session) start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 
 		default:
 			if !s.scanner.Scan() {
@@ -310,7 +310,7 @@ func (s *session) handleStartTLS(args string) error {
 		return err
 	}
 
-	newConn := netx.NewLoggingCon(net.Conn(conn))
+	newConn := netx.NewLoggingConn(net.Conn(conn))
 
 	newConn.RW.Write(s.conn.RW.Bytes())
 	newConn.R.Write(s.conn.R.Bytes())


### PR DESCRIPTION
- Because Event.R was empty for FTP, there were no notifications
- Reuse net.LoggingCon as in SMTP