### PR TITLE
Fix for the case when config file doesn't exists

### DIFF
--- a/internal/cmd/server/config.go
+++ b/internal/cmd/server/config.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"strings"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -39,8 +40,10 @@ func NewConfig(
 
 	// Load config from TOML file.
 	if dir != nil {
-		if err := k.Load(fsprov.Provider(dir, ConfigFileName), toml.Parser()); err != nil {
-			return nil, fmt.Errorf("load config from rawbytes: %w", err)
+		if _, err := dir.Open(ConfigFileName); err == nil || !os.IsNotExist(err) {
+			if err := k.Load(fsprov.Provider(dir, ConfigFileName), toml.Parser()); err != nil {
+				return nil, fmt.Errorf("load config from FS: %w", err)
+			}
 		}
 	}
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -104,7 +104,7 @@ verification_token = "<VERIFICATION_TOKEN>"
 
 func TestConfig_Env(t *testing.T) {
 	cfg, err := server.NewConfig(
-		nil,
+		fstest.MapFS{},
 		func() []string {
 			return []string{
 				"SONAR_IP=<IP>",


### PR DESCRIPTION
The server would fail previously if there is no `config.toml` even though it could be fully configured via env

This pull request includes changes to improve configuration file handling in the `server` package and updates a test case to use a mock filesystem for configuration testing.

### Fix
* [`internal/cmd/server/config.go`](diffhunk://#diff-36f6e0dbf47c1ed520d5deb17dfbbfe2bbc2c4eeb1588df2a45f5b6f0a10503dR6): Added `os` package import and updated the logic in `func NewConfig` to check if the configuration file exists before attempting to load it, improving error handling and clarity. [[1]](diffhunk://#diff-36f6e0dbf47c1ed520d5deb17dfbbfe2bbc2c4eeb1588df2a45f5b6f0a10503dR6) [[2]](diffhunk://#diff-36f6e0dbf47c1ed520d5deb17dfbbfe2bbc2c4eeb1588df2a45f5b6f0a10503dR43-R46)

### Test for this case
* [`tests/config_test.go`](diffhunk://#diff-de48f9b21402c47a4c139ec7a238ff11317111eefd07a6a3a5fe1b8bb6f15344L107-R107): Modified the test case `TestConfig_Env` to use `fstest.MapFS` as a mock filesystem instead of `nil`, enhancing test isolation and reliability.