### PR TITLE
Fix the issue where the lark notification is not sent

### DIFF
--- a/internal/modules/lark/card/v2/card.go
+++ b/internal/modules/lark/card/v2/card.go
@@ -95,7 +95,7 @@ type HeaderText struct {
 	Content string `json:"content"`
 }
 
-func Build(n *modules.Notification) ([]byte, error) {
+func Build(n *modules.Notification, rw []byte) ([]byte, error) {
 	host, _, err := net.SplitHostPort(n.Event.RemoteAddr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to split host port: %w", err)
@@ -262,7 +262,7 @@ func Build(n *modules.Notification) ([]byte, error) {
 
 	body = append(body, Element{
 		Tag:       "markdown",
-		Content:   fmt.Sprintf("```\n%s\n```", n.Event.RW),
+		Content:   fmt.Sprintf("```\n%s\n```", rw),
 		TextAlign: "left",
 		TextSize:  "custom",
 		Margin:    "0px 0px 0px 0px",

--- a/internal/modules/lark/card/v2/card_test.go
+++ b/internal/modules/lark/card/v2/card_test.go
@@ -193,7 +193,7 @@ func TestCard(t *testing.T) {
 			RemoteAddr: "10.13.37.1:1337",
 			ReceivedAt: receivedAt,
 		},
-	})
+	}, []byte("test"))
 
 	require.NoError(t, err)
 


### PR DESCRIPTION
When there is something like email in message, lark returns: msg:The messages do NOT pass the audit, ext=contain sensitive data: EMAIL_ADDRESS,code:230028

So, we need to bypass filter to be able to send notifications about emails