### PR TITLE
Fix telegram notifications and /events get template

### DIFF
--- a/internal/modules/telegram/telegram.go
+++ b/internal/modules/telegram/telegram.go
@@ -68,13 +68,15 @@ func New(
 				templates.Bold("<b>", "</b>"),
 				templates.CodeInline("<code>", "</code>"),
 				templates.CodeBlock(
-					`<pre><code class="language-{{ codeLanguage .Event.Protocol }}">`,
+					`<pre><code class="language-{{ codeLanguage $protocol }}">`,
 					"</code></pre>",
 				),
 			),
-			templates.ExtraFunc("codeLanguage", func(proto models.Proto) string {
+			templates.ExtraFunc("codeLanguage", func(proto string) string {
 				// https://github.com/TelegramMessenger/libprisma#supported-languages
-				switch proto.Category() {
+				category := models.Proto{Name: proto}.Category()
+
+				switch category {
 				case models.ProtoCategoryHTTP:
 					return "http"
 				case models.ProtoCategoryDNS:

--- a/internal/modules/telegram/telegram.go
+++ b/internal/modules/telegram/telegram.go
@@ -68,8 +68,8 @@ func New(
 				templates.Bold("<b>", "</b>"),
 				templates.CodeInline("<code>", "</code>"),
 				templates.CodeBlock(
-					`<blockquote expandable><pre><code class="language-{{ codeLanguage .Event.Protocol }}">`,
-					"</code></pre></blockquote>",
+					`<pre><code class="language-{{ codeLanguage .Event.Protocol }}">`,
+					"</code></pre>",
 				),
 			),
 			templates.ExtraFunc("codeLanguage", func(proto models.Proto) string {

--- a/internal/modules/telegram/telegram.go
+++ b/internal/modules/telegram/telegram.go
@@ -74,12 +74,12 @@ func New(
 			),
 			templates.ExtraFunc("codeLanguage", func(proto models.Proto) string {
 				// https://github.com/TelegramMessenger/libprisma#supported-languages
-				switch proto {
-				case models.ProtoHTTP:
+				switch proto.Category() {
+				case models.ProtoCategoryHTTP:
 					return "http"
-				case models.ProtoDNS:
+				case models.ProtoCategoryDNS:
 					return "dns-zone"
-				case models.ProtoSMTP, models.ProtoFTP:
+				case models.ProtoCategorySMTP, models.ProtoCategoryFTP:
 					return "log"
 				}
 				return ""

--- a/internal/templates/content.go
+++ b/internal/templates/content.go
@@ -130,13 +130,15 @@ const (
 	NotificationBodyID   = "notification/body"
 )
 
-var notificationHeader = `#{{ .Payload.Name }} {{ if eq (upper .Event.Protocol.String) "FTP" -}}
+var notificationHeader = `
+{{- $proto := .Event.Protocol.Category.String -}}
+#{{ .Payload.Name }} {{ if eq (upper $proto) "FTP" -}}
 📂
-{{- else if eq (upper .Event.Protocol.String) "SMTP" -}}
+{{- else if eq (upper $proto) "SMTP" -}}
 📧
-{{- else if eq (upper .Event.Protocol.String) "DNS" -}}
+{{- else if eq (upper $proto) "DNS" -}}
 🔎
-{{- else if eq (upper .Event.Protocol.String) "HTTP" -}}
+{{- else if eq (upper $proto) "HTTP" -}}
 🌐
 {{- else -}}
 ❓

--- a/internal/templates/content.go
+++ b/internal/templates/content.go
@@ -111,6 +111,7 @@ var event = `
 <bold>[{{ $e.Index }}]</bold> - {{ $e.Protocol | upper }} from {{ $e.RemoteAddr }} {{ $e.ReceivedAt.Format "on 02 Jan 2006 at 15:04:05 MST" }}`
 
 var eventsGet = event + `
+{{- $protocol := $e.Protocol }}
 
 <pre>
 {{ $e.RW | b64dec }}
@@ -131,20 +132,22 @@ const (
 )
 
 var notificationHeader = `
-{{- $proto := .Event.Protocol.Category.String -}}
-#{{ .Payload.Name }} {{ if eq (upper $proto) "FTP" -}}
+{{- $category := .Event.Protocol.Category.String -}}
+#{{ .Payload.Name }} {{ if eq (upper $category) "FTP" -}}
 📂
-{{- else if eq (upper $proto) "SMTP" -}}
+{{- else if eq (upper $category) "SMTP" -}}
 📧
-{{- else if eq (upper $proto) "DNS" -}}
+{{- else if eq (upper $category) "DNS" -}}
 🔎
-{{- else if eq (upper $proto) "HTTP" -}}
+{{- else if eq (upper $category) "HTTP" -}}
 🌐
 {{- else -}}
 ❓
 {{- end }} <bold>{{ .Event.Protocol.String | upper }}</bold>`
 
-var notificationBody = `📡 <bold>IP:</bold> <code>{{ regexReplaceAll ":[0-9]+$" .Event.RemoteAddr "" }}</code>
+var notificationBody = `
+{{- $protocol := .Event.Protocol.String -}}
+📡 <bold>IP:</bold> <code>{{ regexReplaceAll ":[0-9]+$" .Event.RemoteAddr "" }}</code>
 📆 <bold>Time:</bold> {{ .Event.ReceivedAt.Format "02 Jan 2006 15:04:05 MST" }}
 {{- $geoip := .Event.Meta.geoip }}
 {{- if $geoip }}


### PR DESCRIPTION
Fixes #195 and #196 

This pull request refactors how protocol information is handled and displayed in Telegram-related templates and notification headers. The main focus is on using protocol categories instead of protocol names directly, which improves consistency and maintainability in how protocols are mapped to display elements and language tags.

**Template Rendering Improvements:**

* Updated the `codeLanguage` template function in `telegram.go` to use protocol categories instead of protocol names, ensuring more consistent syntax highlighting for code blocks in Telegram messages. (`internal/modules/telegram/telegram.go`)
* Simplified the code block template in Telegram messages by removing the expandable blockquote and using a direct `<pre><code>` structure. (`internal/modules/telegram/telegram.go`)

**Notification and Content Template Enhancements:**

* Changed notification header and icon selection logic to use protocol categories, making the icon and label assignment more robust and easier to extend. (`internal/templates/content.go`)
* Introduced local template variables for protocol and category to improve readability and reduce repeated expressions in templates. (`internal/templates/content.go`) [[1]](diffhunk://#diff-c56b89bec199c3285aab7a73bf5a4852e374e48650213d8eed89d8f9181267e1R114) [[2]](diffhunk://#diff-c56b89bec199c3285aab7a73bf5a4852e374e48650213d8eed89d8f9181267e1L133-R150)