### PR TITLE
Updated versions in github workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,12 +37,12 @@ jobs:
 
     steps:
       - name: Install Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: ${{ vars.GO_VERSION }}
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build
         run: make build
@@ -55,7 +55,7 @@ jobs:
           CERTMGR_CA_DIR_URL: 'https://localhost:${{ job.services.pebble.ports[14000] }}/dir'
 
       - name: Code coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ vars.NODE_VERSION }}
           cache: npm
           cache-dependency-path: ./docs/package-lock.json
 
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs/build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,15 +18,15 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: ${{ vars.GO_VERSION }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v4
+      uses: goreleaser/goreleaser-action@v6
       with:
         distribution: goreleaser
         version: latest

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ vars.NODE_VERSION }}
           cache: npm
           cache-dependency-path: ./docs/package-lock.json
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to use newer versions of actions and to leverage reusable variables for tool versions. These changes improve maintainability, security, and consistency across CI/CD pipelines.

**Workflow action version upgrades:**

* Updated `actions/setup-go` from v4 to v5 and replaced hardcoded Go versions with the reusable `${{ vars.GO_VERSION }}` variable in `.github/workflows/build-and-test.yml` and `.github/workflows/release.yml`. [[1]](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948L40-R45) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R29)
* Upgraded `actions/checkout` from v3 to v4 in both `.github/workflows/build-and-test.yml` and `.github/workflows/release.yml`. [[1]](diffhunk://#diff-bc668a2c9f2299cef15b222055b4b4d5311646caec2e7610e540cee18ae9b948L40-R45) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L21-R29)
* Updated `codecov/codecov-action` from v3 to v4 in `.github/workflows/build-and-test.yml`.
* Upgraded `docker/login-action` from v2 to v3 in `.github/workflows/release.yml`.
* Updated `goreleaser/goreleaser-action` from v4 to v6 in `.github/workflows/release.yml`.
* Upgraded `actions/upload-pages-artifact` from v3 to v4 in `.github/workflows/deploy-docs.yml`.

**Version management improvements:**

* Replaced hardcoded Node.js version with `${{ vars.NODE_VERSION }}` in both `.github/workflows/deploy-docs.yml` and `.github/workflows/test-docs.yml`, ensuring centralized version control. [[1]](diffhunk://#diff-87e860af4b9db6c503ed680b6edb6333c6f8d7659f7d1a779a2487466bbc50f6L23-R23) [[2]](diffhunk://#diff-eb28fbd2c2a71f3e5f1fb977bb8dab63cbe6fa76afe4417001671f648beb76abL23-R23)