### PR TITLE
Fix panic on edit message in telegram

### DIFF
--- a/internal/modules/telegram/telegram.go
+++ b/internal/modules/telegram/telegram.go
@@ -168,8 +168,8 @@ func (tg *Telegram) processUpdateWithTelemetry(ctx context.Context, update tgbot
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
 			attribute.Int("telegram.update.id", update.UpdateID),
-			attribute.Int64("telegram.chat.id", update.Message.Chat.ID),
-			attribute.String("telegram.chat.type", update.Message.Chat.Type),
+			attribute.Int64("telegram.chat.id", msg.Chat.ID),
+			attribute.String("telegram.chat.type", msg.Chat.Type),
 		),
 	)
 	defer span.End()


### PR DESCRIPTION
This pull request makes a small adjustment to how telemetry attributes are set in the `processUpdateWithTelemetry` function. The change ensures that chat information is consistently sourced from the `msg` variable instead of `update.Message`, which improves reliability and code clarity.

* Updated telemetry attribute assignment in `internal/modules/telegram/telegram.go` to use `msg.Chat.ID` and `msg.Chat.Type` instead of `update.Message.Chat.ID` and `update.Message.Chat.Type`.